### PR TITLE
Removing PHPUnit requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,6 @@
       "php-mod/curl": "^1.6",
       "php": "^5.6"
   },
-  "require-dev": {
-      "phpunit/phpunit": "^6.0"
-  },
   "license": "Apache-2.0",
   "minimum-stability": "dev",
   "autoload": {


### PR DESCRIPTION
PHPUnit 6 is a very strict requirement. Especially for a package without tests.